### PR TITLE
Enable readonly mode on boolean

### DIFF
--- a/react/human-task-material-renderers/src/components/custom/Boolean/BooleanControl.tsx
+++ b/react/human-task-material-renderers/src/components/custom/Boolean/BooleanControl.tsx
@@ -12,6 +12,7 @@ const BooleanControl = ({
   id,
   label,
   handleChange,
+  enabled,
   path,
   uischema,
 }: ControlProps) => {
@@ -26,6 +27,7 @@ const BooleanControl = ({
       label={label}
       path={path}
       handleChange={handleChange}
+      readonly={!enabled}
       {...restProps}
     />
   );


### PR DESCRIPTION
This add the fix that Nhan added here: [Here](https://github.com/orkes-io/conductor-ui/pull/3336)